### PR TITLE
ctng-compiler-activation 14.3.0 / 15.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_parameters:
   - "--no-error-overlinking"
-channels:
-  - https://staging.continuum.io/pbp/fs/ctng-compilers-feedstock/pr2/80adb18
-  # PBP feature -- should be pr3
-  - https://staging.continuum.io/pbp/fs/ctng-compilers-feedstock/pr0/d0e90d5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 11 %}
+{% set build_num = 12 %}
 
 {% set gcc_major = 13 if gcc_version is undefined else gcc_version.split(".")[0] %}
 # generally, the runtime version of libstdcxx needs to be at least as high
@@ -295,6 +295,12 @@ outputs:
         - {{ library_prefix }}x86_64-w64-mingw32/
       missing_dso_whitelist:  # [linux]
         - /lib64/*            # [linux]
+      overlinking_ignore_patterns:  # [linux]
+        # This is specifically the 'not a valid tag' issue and the '*'
+        # is because there's no indication which file is an issue and
+        # this package is a repack of the artifacts built in
+        # ctng-compilers-feedstock.
+        - '*'                       # [linux]
     requirements:
       host:
         - binutils_impl_{{ cross_target_platform }} {{ binutils_version }}.*


### PR DESCRIPTION
ctng-compiler-activation 14.3.0 

**Destination channel:** Defaults

### Links

- [PKG-9960]
- dev_url:        No/tree/
- conda_forge:    https://github.com/conda-forge/ctng-compiler-activation-feedstock
- pypi:           https://pypi.org/project/ctng-compiler-activation/14.3.0
- pypi inspector: https://inspector.pypi.io/project/ctng-compiler-activation/14.3.0

### Explanation of changes:

- new build number
- remove the staging channels published last time
- for reasons unclear we now get the 'not a valid tag' LIEF issues without an identified file.  Given that `gcc_bootstrap` is a repack of all the of elements previously build in `ctng-compilers-feedstock` this is less of an issue.  Though it would be nice to figure out why conda-build is complaining.


[PKG-9960]: https://anaconda.atlassian.net/browse/PKG-9960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ