### PR TITLE
ctng-compiler-activation 14.3.0 set -u rework

### DIFF
--- a/recipe/activate-g++.sh
+++ b/recipe/activate-g++.sh
@@ -65,8 +65,8 @@ _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo "${thing}" | tr 'a-z+-' 'A-ZX_')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/activate-gcc.sh
+++ b/recipe/activate-gcc.sh
@@ -65,8 +65,8 @@ _tc_activation() {
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'
@@ -111,7 +111,7 @@ if [ "${CONDA_BUILD:-0}" = "1" ]; then
 fi
 
 _CONDA_PYTHON_SYSCONFIGDATA_NAME_USED=${_CONDA_PYTHON_SYSCONFIGDATA_NAME:-@_CONDA_PYTHON_SYSCONFIGDATA_NAME@}
-if [ -n "${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}" ] && [ -n "${SYS_SYSROOT}" ]; then
+if [ -n "${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}" ] && [ -n "${SYS_SYSROOT:-}" ]; then
   if find "$(dirname "$(dirname "${SYS_PYTHON}")")/lib/"python* -type f -name "${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}.py" -exec false {} +; then
     echo ""
     echo "WARNING: The Python interpreter at the following prefix:"

--- a/recipe/activate-gfortran.sh
+++ b/recipe/activate-gfortran.sh
@@ -65,8 +65,8 @@ _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo "${thing}" | tr 'a-z+-' 'A-ZX_')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/deactivate-g++.sh
+++ b/recipe/deactivate-g++.sh
@@ -65,8 +65,8 @@ _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo "${thing}" | tr 'a-z+-' 'A-ZX_')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/deactivate-gcc.sh
+++ b/recipe/deactivate-gcc.sh
@@ -65,8 +65,8 @@ _tc_activation() {
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/deactivate-gfortran.sh
+++ b/recipe/deactivate-gfortran.sh
@@ -65,8 +65,8 @@ _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo "${thing}" | tr 'a-z+-' 'A-ZX_')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 12 %}
+{% set build_num = 13 %}
 
 {% set gcc_major = 13 if gcc_version is undefined else gcc_version.split(".")[0] %}
 # generally, the runtime version of libstdcxx needs to be at least as high


### PR DESCRIPTION
ctng-compiler-activation 14.3.0 

**Destination channel:** Defaults

### Links

- [PKG-12890]
- dev_url:        No/tree/
- conda_forge:    https://github.com/conda-forge/ctng-compiler-activation-feedstock
- pypi:           https://pypi.org/project/ctng-compiler-activation/14.3.0
- pypi inspector: https://inspector.pypi.io/project/ctng-compiler-activation/14.3.0

### Explanation of changes:

- conda 26.1.0 changes how activation scripts are run -- now altogether
- `gdb`'s `post-link.sh` has a `set -u`
- `conda create -n foo -y gdb gcc_<target-platform>` will fail
- cf. https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/176, https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/177 and https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/180
- Note that our activation scripts are not in sync with CF any more and we had an extra unset variable

First graph failed with an IncompleteRead error, see [this graph](https://package-build.anaconda.com/v1/graph/dc35a139-3e55-4ebf-b882-1939615b89a7) instead.

[PKG-12890]: https://anaconda.atlassian.net/browse/PKG-12890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ