### PR TITLE
add clang v21.1 and v22.1 to clang_version matrix

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -27,8 +27,8 @@ cross_stdlib_version:
   - 12    # [win]
 
 clang_version:
-# We don't have clang 21.1 built yet.
-#  - 21.1
+  - 22.1
+  - 21.1
   - 20.1
   - 19.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 13 %}
+{% set build_num = 14 %}
 
 {% set gcc_major = 13 if gcc_version is undefined else gcc_version.split(".")[0] %}
 # generally, the runtime version of libstdcxx needs to be at least as high


### PR DESCRIPTION
ctng-compiler-activation: add clang 21.1 and 22.1

**Destination channel:** defaults

### Links

- [PKG-14328](https://anaconda.atlassian.net/browse/PKG-14328)
- [Upstream repository](https://github.com/conda-forge/ctng-compiler-activation-feedstock)
- Upstream commits mirrored:
  - [ab93362 add clang v21.1](https://github.com/conda-forge/ctng-compiler-activation-feedstock/commit/ab93362)
  - [42602c1 add clang v22.1](https://github.com/conda-forge/ctng-compiler-activation-feedstock/commit/42602c1)
- Relevant dependency PRs:
  - PKG-13331 (clangdev v22.x — already in pkgs/main)
  - PKG-13401 (clang-compiler-activation v22.x — macOS counterpart, already in pkgs/main)
  - PKG-12890 (set -u rework on this same feedstock — already merged on main)

### Explanation of changes:

- Added `21.1` and `22.1` to the `clang_version` matrix in `recipe/conda_build_config.yaml`; removed the stale `# We don't have clang 21.1 built yet.` comment.
- Bumped `build_num` 13 → 14 in `recipe/meta.yaml`.
- **Scope:** CBC matrix expansion only — no script, run_export, or recipe-graph changes. Mirrors what conda-forge already does on their `main` branch.

[PKG-14328]: https://anaconda.atlassian.net/browse/PKG-14328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ