### PR TITLE
ctng-compiler-activation corrections 

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -36,7 +36,7 @@ FINAL_CPPFLAGS:
   - -DNDEBUG -D_FORTIFY_SOURCE=2 -O2
 
 FINAL_CFLAGS_linux_64:
-  - -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
+  - -march=x86-64-v2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
 FINAL_CFLAGS_linux_ppc64le:
   - -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe
 FINAL_CFLAGS_linux_aarch64:
@@ -47,7 +47,7 @@ FINAL_CFLAGS_win_64:
   - -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe
 
 FINAL_CXXFLAGS_linux_64:
-  - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
+  - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=x86-64-v2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
 FINAL_CXXFLAGS_linux_ppc64le:
   - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe
 FINAL_CXXFLAGS_linux_aarch64:
@@ -58,7 +58,7 @@ FINAL_CXXFLAGS_win_64:
   - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe
 
 FINAL_FFLAGS_linux_64:
-  - -fopenmp -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
+  - -fopenmp -march=x86-64-v2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
 FINAL_FFLAGS_linux_ppc64le:
   - -fopenmp -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe
 FINAL_FFLAGS_linux_aarch64:
@@ -83,7 +83,7 @@ FINAL_DEBUG_CPPFLAGS:
   - -D_DEBUG -D_FORTIFY_SOURCE=2 -Og
 
 FINAL_DEBUG_CFLAGS_linux_64:
-  - -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe
+  - -march=x86-64-v2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe
 FINAL_DEBUG_CFLAGS_linux_ppc64le:
   - -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe
 FINAL_DEBUG_CFLAGS_linux_aarch64:
@@ -94,7 +94,7 @@ FINAL_DEBUG_CFLAGS_win_64:
   - -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe
 
 FINAL_DEBUG_CXXFLAGS_linux_64:
-  - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe
+  - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=x86-64-v2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe
 FINAL_DEBUG_CXXFLAGS_linux_ppc64le:
   - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe
 FINAL_DEBUG_CXXFLAGS_linux_aarch64:
@@ -105,7 +105,7 @@ FINAL_DEBUG_CXXFLAGS_win_64:
   - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe
 
 FINAL_DEBUG_FFLAGS_linux_64:
-  - -fopenmp -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none -fvar-tracking-assignments -ffunction-sections -pipe
+  - -fopenmp -march=x86-64-v2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none -fvar-tracking-assignments -ffunction-sections -pipe
 FINAL_DEBUG_FFLAGS_linux_ppc64le:
   - -fopenmp -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe
 FINAL_DEBUG_FFLAGS_linux_aarch64:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 14 %}
+{% set build_num = 15 %}
 
 {% set gcc_major = 13 if gcc_version is undefined else gcc_version.split(".")[0] %}
 # generally, the runtime version of libstdcxx needs to be at least as high


### PR DESCRIPTION
ctng-compiler-activation corrections 

**Destination channel:** Defaults

### Links

- [PKG-13563]
- dev_url:        https://github.com/gcc-mirror/gcc
- conda_forge:    https://github.com/conda-forge/ctng-compiler-activation-feedstock
- pypi:           https://pypi.org/project/ctng-compiler-activation/corrections
- pypi inspector: https://inspector.pypi.io/project/ctng-compiler-activation/corrections

### Explanation of changes:

- new build number
- `s/nocona/x86-64-v2/` something that was targeted for May 2026 https://www.anaconda.com/blog/updated-cpu-requirements-linux-recommendations-windows which is saying we're targeting CPUs built since 2008: https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels
- note that `-mtune=haswell` has been set in this feedstock since inception in 2009

As this package creates `gcc_bootstrap` (by "copying all the files from `ctng-compilers`") I wanted to fix some things there first so they could be encoded here.  But that's all failed to materialise for $reasons.  So let's get this out the door and revisit some of the other issues in due course.  At the time of writing only `binutils` uses `gcc_bootstrap`.

### Testing

Docker on macOS has issues (as ever) so Python 3.15.0b3 falls over fairly early on with an LTO complaint:

```
lto1: internal compiler error: in return_token, at opts-common.cc:2177
```

So careful where you test.

In the meanwhile I built out a fairly random set of packages on a dev instance: `python`, `cython`, `gmp`, `zstd`, `zlib`, `meson`, `bazel`, `scikit-learn`, `pycparser`, `libarchive`, `bzip2`.


[PKG-13563]: https://anaconda.atlassian.net/browse/PKG-13563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ